### PR TITLE
Used Debug.LogError instead of Debug.Log

### DIFF
--- a/SortItemsByName.cs
+++ b/SortItemsByName.cs
@@ -18,6 +18,6 @@ public class SortItemsByName : EditorWindow
                 sortedObjects[i].transform.SetSiblingIndex(initialIndex + i);
             }
         }
-        else Debug.Log("No objects selected to sort");
+        else Debug.LogError("[A-Z Sort Error]: No objects selected in Hierarchy Window to sort");
     }
 }


### PR DESCRIPTION
Replaced the Debug.Log statement with a LogError statement to make it more obvious to the user when there is an error.